### PR TITLE
Fixed vtable layout

### DIFF
--- a/Include/kenshi/Item.h
+++ b/Include/kenshi/Item.h
@@ -243,10 +243,10 @@ public:
 	ogre_unordered_map<GameData*, RaceLimiter::Limiter>::type limits; // 0x8 Member
 	static RaceLimiter* getSingleton();// public RVA = 0x5938D0
 	void addLimit(GameData* dat);// public RVA = 0x761F40
-	virtual bool canEquip(GameData* item, RootObject* who);// public RVA = 0x75C510 vtable offset = 0x0
-	bool _NV_canEquip(GameData* item, RootObject* who);// public RVA = 0x75C510 vtable offset = 0x0
 	virtual bool canEquip(GameData* item, RaceData* race, bool isAnimal);// public RVA = 0x593780 vtable offset = 0x8
 	bool _NV_canEquip(GameData* item, RaceData* race, bool isAnimal);// public RVA = 0x593780 vtable offset = 0x8
+	virtual bool canEquip(GameData* item, RootObject* who);// public RVA = 0x75C510 vtable offset = 0x0
+	bool _NV_canEquip(GameData* item, RootObject* who);// public RVA = 0x75C510 vtable offset = 0x0
 	// no_addr void RaceLimiter(const class RaceLimiter & _a1);// public missing arg names
 	RaceLimiter();// public RVA = 0x592420
 	RaceLimiter* _CONSTRUCTOR();// public RVA = 0x592420

--- a/Include/kenshi/RootObject.h
+++ b/Include/kenshi/RootObject.h
@@ -46,7 +46,7 @@ public:
     void _NV_periodicUpdate();// public RVA = 0x593B70 vtable offset = 0xE8
     virtual const Ogre::Aabb & getAABB() const;// public RVA = 0xD1F10 vtable offset = 0xF0
     const Ogre::Aabb & _NV_getAABB() const;// public RVA = 0xD1F10 vtable offset = 0xF0
-    virtual bool isPhysical() = 0;// public vtable offset = 0xF8
+    virtual bool isPhysical() const = 0;// public vtable offset = 0xF8
     virtual void setVisible(bool _a1) = 0;// public vtable offset = 0x100 missing arg names
     virtual bool getVisible() const;// public RVA = 0xD5290 vtable offset = 0x108
     bool _NV_getVisible() const;// public RVA = 0xD5290 vtable offset = 0x108

--- a/Include/kenshi/util/hand.h
+++ b/Include/kenshi/util/hand.h
@@ -37,11 +37,11 @@ public:
     unsigned int serial; // 0x18 Member
     std::string toString() const;// public RVA = 0x9B3FA0
     void fromString(const std::string& str);// public RVA = 0x9B7120
-    virtual bool operator==(bool a) const;// public RVA = 0xCD0C0 vtable offset = 0x0
-    bool _NV_operator_equal(bool a) const;// public RVA = 0xCD0C0 vtable offset = 0x0
     bool operator==(const RootObjectBase* a) const;// public RVA = 0x593CC0
     virtual bool operator==(const hand& a) const;// public RVA = 0xCD020 vtable offset = 0x8
     bool _NV_operator_equal(const hand& a) const;// public RVA = 0xCD020 vtable offset = 0x8
+    virtual bool operator==(bool a) const;// public RVA = 0xCD0C0 vtable offset = 0x0
+    bool _NV_operator_equal(bool a) const;// public RVA = 0xCD0C0 vtable offset = 0x0
     bool operator!=(const RootObjectBase* a) const;// public RVA = 0x593D60
     virtual bool operator!=(const hand& a) const;// public RVA = 0xCD070 vtable offset = 0x10
     bool _NV_operator_notequal(const hand& a) const;// public RVA = 0xCD070 vtable offset = 0x10


### PR DESCRIPTION
MSVC 2010 places overloaded virtual functions in reverse order of their declarations.
Also, I corrected the signatures so that the Character class and Building class can override isPhysical.